### PR TITLE
Update zed_extension_api to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.6.0"
+zed_extension_api = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 fs_extra = "1.3.0"


### PR DESCRIPTION
0.7.0 introduces a fix when running on windows for the problem: https://github.com/zed-industries/zed/issues/20559

Basically `std::env::current_dir()` will return an absolute path with a leading slash like the following: `\C:\your\current\dir`.
This is not a valid path and causes downloading the netcoredbg binary to fail because it can't write to that directory. The underlying issue is with wasmtime, but zed have implemented a fix that is available in 0.7.0.